### PR TITLE
Add DLL after build for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,11 @@ add_executable(browthon_app ${SOURCE_FILES} ${QRC_FILES})
 
 # deploy on Windows 
 if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-    add_custom_command(TARGET sielo-browser POST_BUILD
-            COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:sielo-browser>)
+    add_custom_command(TARGET browthon_app POST_BUILD
+            COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:browthon_app>)
 elseif(WIN32)
-	add_custom_command(TARGET sielo-browser POST_BUILD
-            COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:sielo-browser>)
+	add_custom_command(TARGET browthon_app POST_BUILD
+            COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:browthon_app>)
 endif()
 
 set(BROWTHON_LIBS Qt5::Widgets Qt5::WebEngine Qt5::WebEngineWidgets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,5 +36,14 @@ find_package(Qt5WebEngineWidgets 5.8 REQUIRED)
 
 add_executable(browthon_app ${SOURCE_FILES} ${QRC_FILES})
 
+# deploy on Windows 
+if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+    add_custom_command(TARGET sielo-browser POST_BUILD
+            COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:sielo-browser>)
+elseif(WIN32)
+	add_custom_command(TARGET sielo-browser POST_BUILD
+            COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:sielo-browser>)
+endif()
+
 set(BROWTHON_LIBS Qt5::Widgets Qt5::WebEngine Qt5::WebEngineWidgets)
 target_link_libraries(browthon_app LINK_PUBLIC ${BROWTHON_LIBS})


### PR DESCRIPTION
When you build Browthon on Windows, you must have all DLL with the created executable to be able to run it. So I added few things in CMakeLists.txt to put all needed files with the exe after build only on Windows :wink: